### PR TITLE
🐛 Bug(syntax): 문법 확인 시, 닫히지 않은 따옴표가 입력되면 Abort 되는 현상 수정

### DIFF
--- a/parse/token/set_quote_token.c
+++ b/parse/token/set_quote_token.c
@@ -17,8 +17,10 @@ void	set_single_quote_token(t_token **token, char *trimmed_line, int *i)
 	}
 	join_token_value(token, trimmed_line, i);
 	if ((*token)->is_in_quote && trimmed_line[*i] == QUOTE)
+	{
 		(*token)->is_in_quote = false;
-	(*i)++;
+		(*i)++;
+	}
 	set_token(*token, trimmed_line, i);
 }
 

--- a/parse/token/set_quote_token.c
+++ b/parse/token/set_quote_token.c
@@ -50,8 +50,10 @@ void	set_double_quote_token(t_token **token, char *trimmed_line, int *i)
 	}
 	join_token_value(token, trimmed_line, i);
 	if ((*token)->is_in_dquote && trimmed_line[*i] == DQUOTE)
+	{
 		(*token)->is_in_dquote = false;
-	(*i)++;
+		(*i)++;
+	}
 	set_token(*token, trimmed_line, i);
 	return ;
 }

--- a/test/ast_tree.c
+++ b/test/ast_tree.c
@@ -4,7 +4,6 @@ void	print_ast_tree(t_ASTnode *ast_tree)
 {
 	t_ASTnode	*leftmost;
 	t_ASTnode	*rightmost;
-	t_ASTnode	*temp;
 
 	if (!ast_tree)
 		return ;


### PR DESCRIPTION
### Description
 - 문법 확인 시, 닫히지 않은 따옴표가 입력되면 Abort 되는 현상 수정
 - (추가) ast_tree 테스트 파일 컴파일 되지 않는 오류 수정
 
## Proposed changes
 - 닫힌 따옴표가 나왔을 때에만 주소값을 증가시킨다.
 - (추가) 사용하지 않는 변수 제거

## Changed Files
- [X] `parse/token/set_quote_token.c`
- [X] `test/ast_tree.c`

## Checklist
- [X] Build Successfully

## Screenshot
- (optional)
