### PR TITLE
🐛 Bug(tokenize): here doc의 limiter로 환경변수가 들어갈 때 환경변수가 해석됨

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -42,6 +42,7 @@ typedef struct s_token {
 	bool				is_in_dquote;
 	bool				is_in_escape;
 	struct s_token		*next;
+	struct s_token		*prev;
 
 }	t_token;
 

--- a/parse/token/add_token_to_tail.c
+++ b/parse/token/add_token_to_tail.c
@@ -8,7 +8,7 @@
  */
 void	add_token_to_tail(t_token **token, t_token *new)
 {
-	t_token	*tmp;
+	t_token	*tail;
 
 	if (!token && !new)
 		return ;
@@ -17,6 +17,7 @@ void	add_token_to_tail(t_token **token, t_token *new)
 		*token = new;
 		return ;
 	}
-	tmp = get_tail_token(token);
-	tmp->next = new;
+	tail = get_tail_token(token);
+	tail->next = new;
+	new->prev = tail;
 }

--- a/parse/token/create_new_token.c
+++ b/parse/token/create_new_token.c
@@ -17,5 +17,6 @@ t_token	*create_new_token(void *value, enum e_token_type type)
 	new_token->is_in_dquote = false;
 	new_token->is_in_escape = false;
 	new_token->next = NULL;
+	new_token->prev = NULL;
 	return (new_token);
 }

--- a/parse/token/interpret_expansion.c
+++ b/parse/token/interpret_expansion.c
@@ -95,7 +95,8 @@ void	interpret_expansion(t_token **token, char *trimmed_line, int *i)
 	if (trimmed_line[*i + 1] == '?')
 		interpret_exit_status(token, i);
 	else if (trimmed_line[*i + 1] == '\0'
-		|| ((*token)->is_in_dquote && trimmed_line[*i + 1] == DQUOTE))
+		|| ((*token)->is_in_dquote && trimmed_line[*i + 1] == DQUOTE)
+		|| ((*token)->prev && (*token)->prev->type == DREDIRECT_IN))
 	{
 		join_token_value(token, trimmed_line, i);
 		(*i)++;

--- a/parse/token/tokenize_line.c
+++ b/parse/token/tokenize_line.c
@@ -10,7 +10,6 @@ t_token	*tokenize_line(char *trimmed_line)
 {
 	t_token	*token;
 	t_token	*new_token;
-	t_token	*prev_token;
 	int		i;
 
 	if (!*trimmed_line)
@@ -25,12 +24,10 @@ t_token	*tokenize_line(char *trimmed_line)
 			free_token_list(&token);
 			return (NULL);
 		}
-		new_token->prev = prev_token;
+		add_token_to_tail(&token, new_token);
 		set_token(new_token, trimmed_line, &i);
 		while (trimmed_line[i] && trimmed_line[i] == SPACE)
 			i++;
-		add_token_to_tail(&token, new_token);
-		prev_token = new_token;
 	}
 	return (token);
 }

--- a/parse/token/tokenize_line.c
+++ b/parse/token/tokenize_line.c
@@ -10,6 +10,7 @@ t_token	*tokenize_line(char *trimmed_line)
 {
 	t_token	*token;
 	t_token	*new_token;
+	t_token	*prev_token;
 	int		i;
 
 	if (!*trimmed_line)
@@ -24,10 +25,12 @@ t_token	*tokenize_line(char *trimmed_line)
 			free_token_list(&token);
 			return (NULL);
 		}
+		new_token->prev = prev_token;
 		set_token(new_token, trimmed_line, &i);
 		while (trimmed_line[i] && trimmed_line[i] == SPACE)
 			i++;
 		add_token_to_tail(&token, new_token);
+		prev_token = new_token;
 	}
 	return (token);
 }


### PR DESCRIPTION
### Description
 - here doc의 limiter로 환경변수가 들어갈 때 환경변수가 해석됨
 
## Proposed changes
 - `s_token`에 이전 토큰을 가리키는 `prev` 추가 후, 이전 토큰이 `DREDIRECT_IN`인지 확인

## Changed Files
- [X] `include/parse.h`
- [X] `parse/token/add_token_to_tail.c`
- [X] `parse/token/create_new_token.c`
- [X] `parse/token/interpret_expansion.c`
- [X] `parse/token/tokenize_line.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette checked
- [X] No leaks

## Screenshot
- (optional)
