### PR TITLE
🐛 Bug(token): token->value 널가드 추가

### DIFF
--- a/parse/token/delete_outer_quotes.c
+++ b/parse/token/delete_outer_quotes.c
@@ -85,7 +85,7 @@ void	delete_outer_quotes(t_token **token)
 	temp_token = *token;
 	while (temp_token)
 	{
-		if (temp_token->type == NORMAL)
+		if (temp_token->type == NORMAL && temp_token->value)
 		{
 			delete_flag = (char *)ft_calloc(ft_strlen(temp_token->value) + 1,
 					sizeof(char));

--- a/parse/token/handle_wildcard.c
+++ b/parse/token/handle_wildcard.c
@@ -139,7 +139,7 @@ int	handle_wildcard(t_ASTnode *ast_tree)
 {
 	if (!ast_tree)
 		return (SUCCESS);
-	if (ast_tree->token->type == NORMAL)
+	if (ast_tree->token->type == NORMAL && ast_tree->token->value)
 	{
 		if (handle_wildcard(ast_tree->left) == ERROR
 			|| handle_wildcard(ast_tree->right) == ERROR)


### PR DESCRIPTION
### Description
 - `token->value == NULL`일 때, `delete_outer_quotes()`와 `handle_wildcard()`에서 abort 나는 현상 수정
 
## Proposed changes
 - 각 함수에 널가드 추가

## Changed Files
- [X] `parse/token/delete_outer_quotes.c`
- [X] `parse/token/handle_wildcard.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- (optional)
