### PR TITLE
🐛 Bug(token): 서브 토큰화 시 앞에 만들어진 토큰이 없을 때 bad access 발생

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,9 @@ endef
 
 # ----- Test ---- #
 TEST_NAME = test
-parse_sources = $(wildcard $(PARSE)/**/*.c)
-parse_sources += $(wildcard $(PARSE)/*.c)
+parse_sources = $(wildcard $(PARSE)/*.c)
+parse_sources += $(wildcard $(PARSE)/**/*.c)
+parse_sources += $(wildcard $(PARSE)/**/**/*.c)
 parse_objects = $(parse_sources:.c=.o)
 tokenize = $(addprefix $(TEST_NAME)/, tokenize.c)
 tokenize_objects = $(addprefix $(TEST_NAME)/, tokenize.o)

--- a/include/parse.h
+++ b/include/parse.h
@@ -92,6 +92,7 @@ int					make_normal_node(t_ASTnode **ast_tree, t_token **current);
 void				add_token_to_tail(t_token **token, t_token *new);
 t_token				*create_new_token(void *value, enum e_token_type type);
 t_token				*get_tail_token(t_token **token);
+t_token				*get_head_token(t_token **token);
 char				*get_join_source(char c);
 void				join_token_value(t_token **token,
 						char *trimmed_line, int *i);

--- a/parse/token/expansion/interpret_exit_status.c
+++ b/parse/token/expansion/interpret_exit_status.c
@@ -1,0 +1,26 @@
+#include "../../../include/parse.h"
+
+/*
+ * Description: 이전 foreground에서 실행된 명령어의 exit status를 토큰의 value에 저장한다.
+ * Param.   #1: 토큰의 주소
+ * Param.   #2: 해석할 환경변수가 포함된 커맨드 라인
+ * Param.   #3: 커맨드 라인 내 환경변수의 시작 인덱스. '?'의 위치를 가리키고 있음
+ * Return     : 없음
+ */
+void	interpret_exit_status(t_token **token, int *i)
+{
+	char	*exit_status;
+	char	*temp;
+
+	exit_status = ft_itoa(0);
+	if (!(*token)->value)
+		(*token)->value = exit_status;
+	else
+	{
+		temp = (*token)->value;
+		(*token)->value = ft_strjoin((*token)->value, exit_status);
+		free(temp);
+		free(exit_status);
+	}
+	*i += 2;
+}

--- a/parse/token/expansion/interpret_expansion.c
+++ b/parse/token/expansion/interpret_expansion.c
@@ -1,29 +1,4 @@
-#include "../../include/parse.h"
-
-/*
- * Description: 이전 foreground에서 실행된 명령어의 exit status를 토큰의 value에 저장한다.
- * Param.   #1: 토큰의 주소
- * Param.   #2: 해석할 환경변수가 포함된 커맨드 라인
- * Param.   #3: 커맨드 라인 내 환경변수의 시작 인덱스. '?'의 위치를 가리키고 있음
- * Return     : 없음
- */
-void	interpret_exit_status(t_token **token, int *i)
-{
-	char	*exit_status;
-	char	*temp;
-
-	exit_status = ft_itoa(0);
-	if (!(*token)->value)
-		(*token)->value = exit_status;
-	else
-	{
-		temp = (*token)->value;
-		(*token)->value = ft_strjoin((*token)->value, exit_status);
-		free(temp);
-		free(exit_status);
-	}
-	*i += 2;
-}
+#include "../../../include/parse.h"
 
 /*
  * Description: 환경변수 키를 찾아서 그 값을 반환한다.

--- a/parse/token/get_head_token.c
+++ b/parse/token/get_head_token.c
@@ -5,7 +5,7 @@
  * Param.  #1 : 토큰 리스트
  * Return     : 토큰 리스트의 맨 앞 토큰
  */
-t_token *get_head_token(t_token **token)
+t_token	*get_head_token(t_token **token)
 {
 	if (!token || !*token)
 		return (NULL);

--- a/parse/token/get_head_token.c
+++ b/parse/token/get_head_token.c
@@ -5,7 +5,7 @@
  * Param.  #1 : 토큰 리스트
  * Return     : 토큰 리스트의 맨 앞 토큰
  */
-t_token	*get_head_token(t_token **token)
+t_token *get_head_token(t_token **token)
 {
 	if (!token || !*token)
 		return (NULL);

--- a/parse/token/get_head_token.c
+++ b/parse/token/get_head_token.c
@@ -1,0 +1,15 @@
+#include "../../include/parse.h"
+
+/*
+ * Description: 토큰 리스트의 맨 앞 토큰을 반환한다.
+ * Param.  #1 : 토큰 리스트
+ * Return     : 토큰 리스트의 맨 앞 토큰
+ */
+t_token *get_head_token(t_token **token)
+{
+	if (!token || !*token)
+		return (NULL);
+	while ((*token)->prev)
+		*token = (*token)->prev;
+	return (*token);
+}

--- a/parse/token/interpret_expansion.c
+++ b/parse/token/interpret_expansion.c
@@ -81,17 +81,41 @@ void	interpret_env(t_token **token, char *trimmed_line, int *i)
 }
 
 /*
+ * Description: 토큰의 문자열을 토큰화 한다.
+ * Param.   #1: 토큰화 할 문자열이 포함된 토큰
+ * Return     : 없음
+ */
+void	sub_tokenize(t_token **token)
+{
+	t_token	*sub_token;
+	t_token	*sub_token_tail;
+
+	sub_token = tokenize_line((*token)->value);
+	if (sub_token)
+	{
+		sub_token->prev = (*token)->prev;
+		if ((*token)->prev)
+			(*token)->prev->next = sub_token;
+		sub_token_tail = get_tail_token(&sub_token);
+		sub_token_tail->next = (*token)->next;
+		if ((*token)->next)
+			(*token)->next->prev = sub_token_tail;
+		free((*token)->value);
+		free(*token);
+		*token = sub_token;
+	}
+}
+
+/*
  * Description: expansion 해석 후, 다음의 동작을 수행 하여 토큰의 값을 수정 한다.
  *              1. 토큰의 값의 앞 뒤 공백을 제거 한다.
- *              2. 토큰의 값이 공백으로 나누어진 문자열이라면, set_token()을 호출하여 토큰을 분리한다.
+ *              2. 토큰의 값이 공백으로 나누어진 문자열 이라면, 토큰화 한다.
  * Param.   #1: 토큰의 주소
  * Return     : 없음
  */
 void	postprocess_expansion(t_token **token)
 {
 	char	*trimmed_value;
-	t_token	*sub_token;
-	t_token	*sub_token_tail;
 
 	if (!(*token)->value)
 		return ;
@@ -100,19 +124,7 @@ void	postprocess_expansion(t_token **token)
 	(*token)->value = trimmed_value;
 	delete_outer_quotes(token);
 	if (ft_strchr((*token)->value, BLANK))
-	{
-		sub_token = tokenize_line((*token)->value);
-		if (sub_token)
-		{
-			sub_token->prev = (*token)->prev;
-			(*token)->prev->next = sub_token;
-			sub_token_tail = get_tail_token(&sub_token);
-			sub_token_tail->next = (*token)->next;
-			free((*token)->value);
-			free(*token);
-			*token = sub_token;
-		}
-	}
+		sub_tokenize(token);
 }
 
 /*

--- a/parse/token/tokenize_line.c
+++ b/parse/token/tokenize_line.c
@@ -26,8 +26,9 @@ t_token	*tokenize_line(char *trimmed_line)
 		}
 		add_token_to_tail(&token, new_token);
 		set_token(&new_token, trimmed_line, &i);
+		token = new_token;
 		while (trimmed_line[i] && trimmed_line[i] == BLANK)
 			i++;
 	}
-	return (token);
+	return (get_head_token(&token));
 }


### PR DESCRIPTION
### Description
 - 서브 토큰화 시, 앞에 만들어진 토큰이 없을 때 BAD_ACCESS 발생
 
## Proposed changes
 - 서브 토큰 앞/뒤에 토큰이 있을 때에만 앞/뒤 토큰의 주소에 접근

## Changed Files
- [X] `Makefile`
- [X] `include/parse.h`
- [X] `parse/token/expansion/interpret_exit_status.c`
- [X] `parse/token/expansion/interpret_expansion.c`
- [X] `parse/token/get_head_token.c`
- [X] `parse/token/tokenize_line.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- (optional)
