### PR TITLE
🐛 Bug(ast_tree): DEADLYSIGNAL in wildcard

### DIFF
--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -160,7 +160,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 
 	if (!(*ast_tree) || is_operator((*ast_tree)->token))
 	{
-		new_node = create_new_node(NULL);
+		new_node = create_new_node(*current);
 		if (!new_node)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);


### PR DESCRIPTION
### Description
 - 특정 명령어 입력 시, DEADLYSIGNAL이 발생하며 의도치 않은 프로그램 종료 발생
 - `< *`, `> *`, `*;`
 
## Proposed changes
 - AST Tree를 만들 때, node의 토큰 값이 지정되지 않아 발생하므로, 토큰 생성 시, node의 토큰에 현재 토큰을 할당

## Changed Files
- [X] `parse/ASTtree/make_node.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- (optional)
