### PR TITLE
🐛 Bug(wildcard): wildcard deadsignal

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -9,7 +9,7 @@
 # include <errno.h>
 
 enum	e_token_type {
-	NORMAL = 1,
+	NORMAL,
 	REDIRECT_IN = '<',
 	DREDIRECT_IN,
 	REDIRECT_OUT = '>',

--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -170,7 +170,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 		|| (*current)->type == DREDIRECT_IN
 		|| (*current)->type == DREDIRECT_OUT)
 		return (make_redirection_node(ast_tree, current));
-	else if ((*current)->type == NORMAL)
+	else if ((*current)->type == NORMAL || (*current)->type == WILDCARD)
 		return (make_normal_node(ast_tree, current));
 	return (SUCCESS);
 }

--- a/parse/is_valid_syntax.c
+++ b/parse/is_valid_syntax.c
@@ -48,8 +48,7 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 		if (temp->type == REDIRECT_IN || temp->type == REDIRECT_OUT
 			|| temp->type == DREDIRECT_IN || temp->type == DREDIRECT_OUT)
 		{
-			temp = temp->next;
-			if (!temp || temp->type != NORMAL)
+			if (!temp->next || temp->next->type != NORMAL)
 				return (false);
 		}
 		temp = temp->next;

--- a/parse/token/handle_wildcard.c
+++ b/parse/token/handle_wildcard.c
@@ -137,18 +137,13 @@ int	interpret_wildcard(t_ASTnode **node)
  */
 int	handle_wildcard(t_ASTnode *ast_tree)
 {
-	if (!ast_tree)
+	if (!ast_tree || !ast_tree->token)
 		return (SUCCESS);
-	if (ast_tree->token->type == NORMAL && ast_tree->token->value)
-	{
-		if (handle_wildcard(ast_tree->left) == ERROR
-			|| handle_wildcard(ast_tree->right) == ERROR)
-			return (ERROR);
-		if (!ft_strchr(ast_tree->token->value, WILDCARD))
-			return (SUCCESS);
-		ast_tree->token->type = WILDCARD;
-		if (interpret_wildcard(&ast_tree) == ERROR)
-			return (ERROR);
-	}
+	if (ast_tree->token->type == WILDCARD && interpret_wildcard(&ast_tree) == ERROR)
+		return (ERROR);
+	if (handle_wildcard(ast_tree->left) == ERROR)
+		return (ERROR);
+	if (handle_wildcard(ast_tree->right) == ERROR)
+		return (ERROR);
 	return (SUCCESS);
 }

--- a/parse/token/handle_wildcard.c
+++ b/parse/token/handle_wildcard.c
@@ -139,7 +139,8 @@ int	handle_wildcard(t_ASTnode *ast_tree)
 {
 	if (!ast_tree || !ast_tree->token)
 		return (SUCCESS);
-	if (ast_tree->token->type == WILDCARD && interpret_wildcard(&ast_tree) == ERROR)
+	if (ast_tree->token->type == WILDCARD
+		&& interpret_wildcard(&ast_tree) == ERROR)
 		return (ERROR);
 	if (handle_wildcard(ast_tree->left) == ERROR)
 		return (ERROR);

--- a/parse/token/set_token.c
+++ b/parse/token/set_token.c
@@ -21,7 +21,7 @@ void	set_token(t_token **token, char *trimmed_line, int *i)
 	{
 		set_normal_token(token, trimmed_line, i);
 		if (!ft_strncmp((*token)->value, "*", ft_strlen((*token)->value))
-			&& (*token)->prev->type != DREDIRECT_IN)
+			&& ((*token)->prev && (*token)->prev->type != DREDIRECT_IN))
 			(*token)->type = WILDCARD;
 	}
 }


### PR DESCRIPTION
### Description
 - `*` 입력 시, DEADSIGNAL 문제
 - 와일드카드가 빈 값으로 해석되어 들어감
 - `handle_wildcard` 리팩터링
 
## Proposed changes
 - `set_token.c` 내 노멀 토큰의 값이 와일드카드 일 때, 앞의 토큰 값을 검사하는 과정에서 앞의 토큰이 있는지를 먼저 체크하게 함
 - `parse.h` 내 NORMAL의 값을 0으로 수정

## Changed Files
- [X] `include/parse.h`
- [X] `parse/ASTtree/make_node.c`
- [X] `parse/is_valid_syntax.c`
- [X] `parse/token/handle_wildcard.c`
- [X] `parse/token/set_token.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- <img width="596" alt="스크린샷 2023-03-30 오전 3 05 43" src="https://user-images.githubusercontent.com/50291995/228631218-d58da0af-7b4c-4fd6-acb3-ae783dab4441.png">
