### PR TITLE
🐛 Bug(here_doc): errors and suggestions for heredoc

### DIFF
--- a/parse/ASTtree/add_node_to_direction.c
+++ b/parse/ASTtree/add_node_to_direction.c
@@ -14,6 +14,8 @@
 void	add_node_to_direction(t_ASTnode **node, t_ASTnode *new_node,
 							int direction)
 {
+	if (*node == new_node)
+		return ;
 	if (*node && direction == LEFT)
 		(*node)->left = new_node;
 	else if (*node && direction == RIGHT)

--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -98,7 +98,10 @@ int	make_redirection_node(t_ASTnode **ast_tree, t_token **current)
 
 	if (!(*current)->next)
 		return (FAIL);
-	new_node = create_new_node(*current);
+	if ((*ast_tree)->token != *current)
+		new_node = create_new_node(*current);
+	else
+		new_node = *ast_tree;
 	if (!new_node)
 		return (ERROR);
 	(*current) = (*current)->next;

--- a/parse/is_valid_syntax.c
+++ b/parse/is_valid_syntax.c
@@ -46,8 +46,8 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 	{
 		if (temp->type == REDIRECT_IN || temp->type == REDIRECT_OUT)
 		{
-			if (!temp->next
-				|| (temp->next->type != NORMAL && temp->next->type != AMPERSAND))
+			if (!temp->next || (temp->next->type != NORMAL
+					&& temp->next->type != AMPERSAND))
 			{
 				*token_value = temp->value;
 				return (false);

--- a/parse/is_valid_syntax.c
+++ b/parse/is_valid_syntax.c
@@ -44,12 +44,22 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 	temp = token;
 	while (temp)
 	{
-		*token_value = temp->value;
-		if (temp->type == REDIRECT_IN || temp->type == REDIRECT_OUT
-			|| temp->type == DREDIRECT_IN || temp->type == DREDIRECT_OUT)
+		if (temp->type == REDIRECT_IN || temp->type == REDIRECT_OUT)
+		{
+			if (!temp->next
+				|| (temp->next->type != NORMAL && temp->next->type != AMPERSAND))
+			{
+				*token_value = temp->value;
+				return (false);
+			}
+		}
+		else if (temp->type == DREDIRECT_IN || temp->type == DREDIRECT_OUT)
 		{
 			if (!temp->next || temp->next->type != NORMAL)
+			{
+				*token_value = temp->value;
 				return (false);
+			}
 		}
 		temp = temp->next;
 	}

--- a/parse/token/tokenize_line.c
+++ b/parse/token/tokenize_line.c
@@ -18,7 +18,7 @@ t_token	*tokenize_line(char *trimmed_line)
 	token = NULL;
 	while (trimmed_line[i])
 	{
-		new_token = create_new_token(NULL, 0);
+		new_token = create_new_token(NULL, NORMAL);
 		if (!new_token)
 		{
 			free_token_list(&token);


### PR DESCRIPTION
### Description
 - `<< a`, `<< *`, `2>&1`, `2<&1`의 경우, 정상적인 문법임에도 불구하고 유효하지 않은 문법으로 취급됨
 - `<< *`의 경우, 노드를 생성할 때 `<<` 노드가 두 개 생성됨
 
## Proposed changes
 - 리다이렉션 뒤에 NORMAL 토큰이 오는지를 보기 때문에, 처음 토큰을 생성할 때 type을 0이 아닌 NORMAL로 초기화
 - 리다이렉션 노드를 생성할 때, 현재 토큰과 루트 노드의 토큰이 같은 주소인지를 확인. 같은 주소라면 파일 디스크립터 노드만 생성 후 자식 노드로 연결

## Changed Files
- [X] `parse/ASTtree/add_node_to_direction.c`
- [X] `parse/ASTtree/make_node.c`
- [X] `parse/is_valid_syntax.c`
- [X] `parse/token/tokenize_line.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette checked
- [X] No leaks

## Screenshot
- `test-ast` 실행
<img width="459" alt="스크린샷 2023-03-30 오후 6 07 19" src="https://user-images.githubusercontent.com/50291995/228789472-5f23ad32-835f-4f10-afeb-aaa9e4da7089.png">
