### PR TITLE
🐛 Bug(ast_tree): Bug: 첫 normal 노드가 중복 생성되는 버그

### DIFF
--- a/parse/ASTtree/add_node_to_direction.c
+++ b/parse/ASTtree/add_node_to_direction.c
@@ -14,7 +14,7 @@
 void	add_node_to_direction(t_ASTnode **node, t_ASTnode *new_node,
 							int direction)
 {
-	if (*node == new_node)
+	if (!node || *node == new_node)
 		return ;
 	if (*node && direction == LEFT)
 		(*node)->left = new_node;

--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -168,6 +168,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);
 		*ast_tree = new_node;
+		*current = (*current)->next;
 	}
 	if ((*current)->type == REDIRECT_IN || (*current)->type == REDIRECT_OUT
 		|| (*current)->type == DREDIRECT_IN


### PR DESCRIPTION
…토큰을 가리키도록 수정

### Description
 - 첫 normal 노드가 중복 생성됨
 
## Proposed changes
 - 루트 노드가 없는 상태에서 처음으로 command 노드를 생성하거나, operator 노드를 생성하면 토큰이 바로 다음 토큰을 가리키게 함

## Changed Files
- [X] `parse/ASTtree/add_node_to_direction.c`
- [X] `parse/ASTtree/make_node.c`

## Checklist
- [X] Build Successfully
- [X] Test Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
`echo a | echo b | ls -al` 입력 시
<img width="640" alt="스크린샷 2023-03-30 오후 8 52 15" src="https://user-images.githubusercontent.com/50291995/228827557-a066ceee-295e-4273-96c7-88b2068a3822.png">

이는 아래의 트리 구조와 같음
![20230330_191944](https://user-images.githubusercontent.com/50291995/228827763-d7ba0fc8-3e38-4c25-b19b-b8fcbb321d70.jpg)
