### PR TITLE
🐛 Bug(ast_tree): 인자 하나만 넣었을 때 segmentation fault

### DIFF
--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -168,7 +168,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);
 		*ast_tree = new_node;
-		*current = (*current)->next;
+		return (SUCCESS);
 	}
 	if ((*current)->type == REDIRECT_IN || (*current)->type == REDIRECT_OUT
 		|| (*current)->type == DREDIRECT_IN


### PR DESCRIPTION
### Description
 - 인자 하나만 넣었을 때 segmentation fault 발생
 - `make_command_nodes()`에서 토큰 주소값을 다음으로 옮긴 후에 `make_ast_tree()`에서 또다시 토큰의 주소값을 다음으로 옮김
 - 토큰이 하나라면 이미 `make_command_nodes()`에서 다음 주소값인 `NULL`을 가리키기 때문에, 이 상태에서 또다시 다음 토큰에 접근하려 하면서 segmenation fault 발생
 
## Proposed changes
 - `make_command_nodes()` 내 루트 노드가 없거나 연산자 노드일 경우, 노드 생성이 끝나고 토큰의 주소값을 다음으로 가리키는 것이 아니라, 노드 생성 후 바로 성공을 반환하게 함

## Changed Files
- [X] `parse/ASTtree/make_node.c`

## Checklist
- [X] `ls`
- [X] `echo hi`
- [X] `echo a | echo b`
- [X] `echo a || echo b`
- [X] `echo a && echo b`
- [X] `echo | ls | hi | cat`
- [X] `ls *`
- [X] `****`
- [X] `*;`
- [X] `*`
- [X] `<< *`
- [X] `>> *`
- [X] `< *`
- [X] `> *`
- [X] `2>&1`
- [X] `ls > $HOME`
- [X] `>>>>>>>`

