### PR TITLE
71 bug 연산자의 개수가 짝수일 때 segmentation fault

### DIFF
--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -168,7 +168,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);
 		*ast_tree = new_node;
-		return (SUCCESS);
+		*current = (*current)->next;
 	}
 	if ((*current)->type == REDIRECT_IN || (*current)->type == REDIRECT_OUT
 		|| (*current)->type == DREDIRECT_IN

--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -168,7 +168,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);
 		*ast_tree = new_node;
-		*current = (*current)->next;
+		return (SUCCESS);
 	}
 	if ((*current)->type == REDIRECT_IN || (*current)->type == REDIRECT_OUT
 		|| (*current)->type == DREDIRECT_IN

--- a/parse/is_valid_syntax.c
+++ b/parse/is_valid_syntax.c
@@ -118,7 +118,7 @@ bool	is_valid_command(t_token *token, char **token_value)
 	while (temp)
 	{
 		*token_value = temp->value;
-		if (temp->type == AMPERSAND || temp->type == PIPE)
+		if (is_operator(temp) || temp->type == AMPERSAND)
 		{
 			if (!is_in_normal)
 				return (false);


### PR DESCRIPTION
### Description
 - 연산자의 개수가 짝수일 때 segmentation fault 발생
 
## Proposed changes
 - normal node 생성 시, 토큰이 다음 토큰을 가리키지 않게 함

## Changed Files
- [X] *.swift

## Checklist
## 단항
- [X] `ls`
- [X] `cat`
- [X] `||`
- [X] `|`
- [X] `&&`
- [X] `>`
- [X] `>>`
- [X] `<`
- [X] `<<`
- [X] `*`
- [X] `$HOME`
- [X] `'$HOME`
- [X] `$"HOME"`
- [X] `"$HOME"`
- [X] `"$"HOME`

## 이항
- [X] `ls cat`
- [X] `ls | cat`
- [X] `ls || cat`
- [X] `ls && cat`
- [X] `ls -l | cat`
- [X] `echo  hi > ls`
- [X] `echo hi >> hi`
- [x] `echo hi > $HOME`
- [x] `echo hi >> $HOME`
- [x] `echo hi < $HOME`
- [x] `echo hi << $HOME`
- [x] `ls *`

## 다항
- [x] `ls ls ls`
- [x] `ls | ls | ls | ls`
- [x] `cat || cat || cat || cat`
- [x] `cat && cat && cat && cat`
- [x] `| | | |`
- [x] `|| || || ||`
- [x] `&& && && &&`

## Screenshot
- (optional)
