### PR TITLE
🐛 Bug(syntax): ended independently except for normal type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ INCS		=	-I ./include -I$(RDLINE_DIR)/include
 object_dir	=	./objects
 
 PROMPT		=	prompt
+ERROR		=	error
 PARSE		=	pars
 HISTORY		=	history
 EXECUTE		=	execute
@@ -54,6 +55,8 @@ sources1 :=
 sources1 += main.c
 
 sources1 += $(PROMPT)/prompt.c
+
+sources1 += $(ERROR)/syntax_error.c
 
 sources1 += $(EXECUTE)/argv.c
 sources1 += $(EXECUTE)/child.c
@@ -129,7 +132,8 @@ endef
 
 # ----- Test ---- #
 TEST_NAME = test
-parse_sources = $(wildcard $(PARSE)/*.c)
+parse_sources = $(wildcard $(ERROR)/*.c)
+parse_sources += $(wildcard $(PARSE)/*.c)
 parse_sources += $(wildcard $(PARSE)/**/*.c)
 parse_sources += $(wildcard $(PARSE)/**/**/*.c)
 parse_objects = $(parse_sources:.c=.o)

--- a/error/syntax_error.c
+++ b/error/syntax_error.c
@@ -1,0 +1,24 @@
+#include "../include/minishell.h"
+
+/*
+ * Description: 토큰의 syntax error를 출력한다.
+ * Param.   #1: 에러가 발생한 토큰의 주소
+ * Return     : 없음
+ */
+void    print_syntax_error(t_token *token)
+{
+    ft_putstr_fd("JIP-shell: syntax error near unexpected token `", 2);
+    ft_putstr_fd(token->value, 2);
+    ft_putendl_fd("'", 2);
+}
+
+/*
+ * Description: 토큰의 command not found를 출력한다.
+ * Param.   #1: 에러가 발생한 토큰의 주소
+ * Return     : 없음
+ */
+ void   print_command_not_found(t_token *token)
+ {
+    ft_putstr_fd("JIP-shell: command not found: ", 2);
+	ft_putendl_fd(token->value, 2);
+ }

--- a/include/parse.h
+++ b/include/parse.h
@@ -58,15 +58,21 @@ typedef struct s_cursor {
 	void	*next;
 }	t_cursor;
 
+/*---------------------------------- ERROR ----------------------------------*/
+void    print_syntax_error(t_token *token);
+void	print_command_not_found(t_token *token);
+
 /*---------------------------------- PARSE ----------------------------------*/
 char				**preprocess_line(char *line);
 t_ASTnode			*parse_command_line(char *line);
 bool				is_valid_syntax(t_token *token);
-bool				is_valid_redirection(t_token *token, char **token_value);
-bool				is_pair_of_parenthesis(t_token *token, char **token_value);
+bool				is_valid_redirection(t_token *token);
+bool				is_pair_of_parenthesis(t_token *token);
 t_token				*get_last_token_in_parenthesis(t_token **token);
-bool				is_valid_parenthesis(t_token *token, char **token_value);
-bool				is_valid_command(t_token *token, char **token_value);
+t_token				*get_tokens_in_parenthesis(t_token *open, t_token *close);
+bool				is_correct_in_parenthesis(t_token *open, t_token *close);
+bool				is_valid_parenthesis(t_token *token);
+bool				is_valid_command(t_token *token);
 t_ASTnode			*make_ast_tree(t_token **token);
 
 /*--------------------------------- AST_TREE --------------------------------*/
@@ -107,6 +113,7 @@ void				set_token(t_token **token, char *trimmed_line, int *i);
 void				free_token_list(t_token **token);
 t_token				*tokenize_line(char *trimmed_line);
 bool				is_operator(t_token *token);
+bool				is_redirection(t_token *token);
 bool				is_quote(char c);
 void				interpret_expansion(t_token **token, char *trimmed_line,
 						int *i);

--- a/parse/is_valid_syntax.c
+++ b/parse/is_valid_syntax.c
@@ -131,6 +131,8 @@ bool	is_valid_command(t_token *token, char **token_value)
 			temp = temp->next;
 		temp = temp->next;
 	}
+	if (!is_in_normal)
+		return(false);
 	return (true);
 }
 

--- a/parse/token/get_tokens_in_parenthesis.c
+++ b/parse/token/get_tokens_in_parenthesis.c
@@ -1,0 +1,31 @@
+#include "../../include/minishell.h"
+
+/*
+ * Description: 열린 괄호 다음부터 닫힌 괄호 전까지의 토큰을 복제한다.
+ * Param.   #1: 열린 괄호 토큰의 주소
+ * Param.   #2: 닫힌 괄호 토큰의 주소
+ * Return     : 복제한 토큰 리스트의 첫 번째 요소의 주소
+ */
+ t_token    *get_tokens_in_parenthesis(t_token *open, t_token *close)
+ {
+    t_token *tokens_in_parent;
+    t_token *new_token;
+    t_token *temp;
+
+    temp = open->next;
+    tokens_in_parent = NULL;
+    while (temp->next && temp != close)
+    {
+        if (!tokens_in_parent)
+            tokens_in_parent = create_new_token(ft_strdup(temp->value), temp->type);
+        else
+        {
+            new_token = create_new_token(ft_strdup(temp->value), temp->type);
+            add_token_to_tail(&tokens_in_parent, new_token);
+        }
+        temp = temp->next;
+    }
+    if (temp != close)
+        free_token_list(&tokens_in_parent);
+    return (tokens_in_parent);
+ }

--- a/parse/token/get_tokens_in_parenthesis.c
+++ b/parse/token/get_tokens_in_parenthesis.c
@@ -6,26 +6,27 @@
  * Param.   #2: 닫힌 괄호 토큰의 주소
  * Return     : 복제한 토큰 리스트의 첫 번째 요소의 주소
  */
- t_token    *get_tokens_in_parenthesis(t_token *open, t_token *close)
- {
-    t_token *tokens_in_parent;
-    t_token *new_token;
-    t_token *temp;
+t_token	*get_tokens_in_parenthesis(t_token *open, t_token *close)
+{
+	t_token	*tokens_in_parent;
+	t_token	*new_token;
+	t_token	*temp;
 
-    temp = open->next;
-    tokens_in_parent = NULL;
-    while (temp->next && temp != close)
-    {
-        if (!tokens_in_parent)
-            tokens_in_parent = create_new_token(ft_strdup(temp->value), temp->type);
-        else
-        {
-            new_token = create_new_token(ft_strdup(temp->value), temp->type);
-            add_token_to_tail(&tokens_in_parent, new_token);
-        }
-        temp = temp->next;
-    }
-    if (temp != close)
-        free_token_list(&tokens_in_parent);
-    return (tokens_in_parent);
- }
+	temp = open->next;
+	tokens_in_parent = NULL;
+	while (temp->next && temp != close)
+	{
+		if (!tokens_in_parent)
+			tokens_in_parent = create_new_token(ft_strdup(temp->value),
+					temp->type);
+		else
+		{
+			new_token = create_new_token(ft_strdup(temp->value), temp->type);
+			add_token_to_tail(&tokens_in_parent, new_token);
+		}
+		temp = temp->next;
+	}
+	if (temp != close)
+		free_token_list(&tokens_in_parent);
+	return (tokens_in_parent);
+}

--- a/parse/token/type_checker.c
+++ b/parse/token/type_checker.c
@@ -33,10 +33,10 @@ bool	is_quote(char c)
  * Return     : true : 따옴표가 맞음
  *              false: 따옴표가 아님
  */
- bool	is_redirection(t_token *token)
- {
+bool	is_redirection(t_token *token)
+{
 	if (token->type == REDIRECT_IN || token->type == REDIRECT_OUT
 		|| token->type == DREDIRECT_IN || token->type == DREDIRECT_OUT)
 		return (true);
 	return (false);
- }
+}

--- a/parse/token/type_checker.c
+++ b/parse/token/type_checker.c
@@ -26,3 +26,17 @@ bool	is_quote(char c)
 		return (true);
 	return (false);
 }
+
+/*
+ * Description: 현재 토큰이 리다이렉션 토큰인지 확인한다.
+ * Param.   #1: 확인할 토큰
+ * Return     : true : 따옴표가 맞음
+ *              false: 따옴표가 아님
+ */
+ bool	is_redirection(t_token *token)
+ {
+	if (token->type == REDIRECT_IN || token->type == REDIRECT_OUT
+		|| token->type == DREDIRECT_IN || token->type == DREDIRECT_OUT)
+		return (true);
+	return (false);
+ }

--- a/parse/validation/is_valid_syntax.c
+++ b/parse/validation/is_valid_syntax.c
@@ -12,22 +12,14 @@
  */
 bool	is_valid_syntax(t_token *token)
 {
-	char	*token_value;
-
-	if (!is_pair_of_parenthesis(token, &token_value)
-		|| !is_valid_parenthesis(token, &token_value)
-		|| !is_valid_redirection(token, &token_value))
-	{
-		ft_putstr_fd("JIP-shell: syntax error near unexpected token `", 2);
-		ft_putstr_fd(token_value, 2);
-		ft_putendl_fd("'", 2);
+	if (!is_pair_of_parenthesis(token))
 		return (false);
-	}
-	else if (!is_valid_command(token, &token_value))
-	{
-		ft_putstr_fd("JIP-shell: command not found: ", 2);
-		ft_putendl_fd(token_value, 2);
+	else if (!is_valid_parenthesis(token))
 		return (false);
-	}
-	return (true);
+	else if (!is_valid_redirection(token))
+		return (false);
+	else if (!is_valid_command(token))
+		return (false);
+	else
+		return (true);
 }

--- a/parse/validation/validation_util.c
+++ b/parse/validation/validation_util.c
@@ -155,7 +155,7 @@ bool	is_valid_command(t_token *token)
 			|| is_redirection(temp))
 		{
 			if ((prev && (is_operator(prev) || prev->type == AMPERSAND
-					|| is_redirection(prev))) || !temp->next)
+						|| is_redirection(prev))) || !temp->next)
 			{
 				print_command_not_found(temp);
 				return (false);

--- a/parse/validation/validation_util.c
+++ b/parse/validation/validation_util.c
@@ -157,7 +157,7 @@ bool	is_valid_command(t_token *token)
 			is_in_normal = true;
 		else if (temp->type == REDIRECT_IN || temp->type == REDIRECT_OUT
 			|| temp->type == DREDIRECT_IN || temp->type == DREDIRECT_OUT)
-			temp = temp->next;
+			is_in_normal = false;
 		temp = temp->next;
 	}
 	if (!is_in_normal)

--- a/parse/validation/validation_util.c
+++ b/parse/validation/validation_util.c
@@ -7,7 +7,7 @@
  * Return     : true : 괄호의 짝이 맞음
  *            : false: 괄호의 짝이 맞지 않음
  */
-bool	is_pair_of_parenthesis(t_token *token, char **token_value)
+bool	is_pair_of_parenthesis(t_token *token)
 {
 	t_token	*temp;
 	int		parenthesis_count;
@@ -16,17 +16,20 @@ bool	is_pair_of_parenthesis(t_token *token, char **token_value)
 	temp = token;
 	while (temp)
 	{
-		*token_value = temp->value;
 		if (temp->type == PARENTHESIS_OPEN)
 			parenthesis_count++;
 		else if (temp->type == PARENTHESIS_CLOSE)
 			parenthesis_count--;
 		if (parenthesis_count < 0)
+		{
+			print_syntax_error(temp);
 			return (false);
+		}
 		temp = temp->next;
 	}
 	if (parenthesis_count == 0)
 		return (true);
+	print_syntax_error(temp);
 	return (false);
 }
 
@@ -37,7 +40,7 @@ bool	is_pair_of_parenthesis(t_token *token, char **token_value)
  * Return     : true : 리다이렉션 문법이 유효함
  *            : false: 리다이렉션 문법이 유효하지 않음
  */
-bool	is_valid_redirection(t_token *token, char **token_value)
+bool	is_valid_redirection(t_token *token)
 {
 	t_token	*temp;
 
@@ -49,7 +52,7 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 			if (!temp->next || (temp->next->type != NORMAL
 					&& temp->next->type != AMPERSAND))
 			{
-				*token_value = temp->value;
+				print_syntax_error(temp);
 				return (false);
 			}
 		}
@@ -57,7 +60,7 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 		{
 			if (!temp->next || temp->next->type != NORMAL)
 			{
-				*token_value = temp->value;
+				print_syntax_error(temp);
 				return (false);
 			}
 		}
@@ -67,36 +70,63 @@ bool	is_valid_redirection(t_token *token, char **token_value)
 }
 
 /*
+ * Description: 괄호 내 명령어의 문법이 올바른지 검사한다.
+ * Param.   #1: 열린 괄호 토큰의 주소
+ * Param.   #2: 닫힌 괄호 토큰의 주소
+ * Return     : true : 괄호 내 문법이 올바름
+ *            : false: 괄호 내 문법이 올바르지 않음
+ */
+bool	is_correct_in_parenthesis(t_token *open, t_token *close)
+{
+	t_token	*tokens_in_parent;
+
+	tokens_in_parent = get_tokens_in_parenthesis(open, close);
+	if (!tokens_in_parent)
+		return (false);
+	if (!is_valid_syntax(tokens_in_parent))
+	{
+		free_token_list(&tokens_in_parent);
+		return (false);
+	}
+	free_token_list(&tokens_in_parent);
+	return (true);
+}
+
+/*
  * Description: 괄호의 위치가 유효한지 검사한다.
+ * 				만약 '(' 앞의 토큰이 존재할 경우, NORMAL 토큰이거나 리다이렉션이라면 false이다.
+ *				만약 ')' 앞의 토큰이 노멀 토큰이 아니거나, 
  * Param.   #1: 토큰 리스트의 첫 번째 토큰 주소
  * Param.   #2: 토큰의 값(value)을 담을 문자열 포인터
  * Return     : true : 괄호가 올바른 위치에 있음
  *            : false: 괄호가 잘못된 위치에 있음
  */
-bool	is_valid_parenthesis(t_token *token, char **token_value)
+bool	is_valid_parenthesis(t_token *token)
 {
-	t_token	*prev;
-	t_token	*next;
 	t_token	*temp;
+	t_token	*open;
+	t_token	*close;
 
-	prev = NULL;
 	temp = token;
-	while (temp)
+	while (temp->next)
 	{
-		*token_value = temp->value;
-		if (temp->type == PARENTHESIS_OPEN)
-		{
+		while (temp->next && temp->type != PARENTHESIS_OPEN)
 			temp = temp->next;
-			next = get_last_token_in_parenthesis(&temp);
-			if (!next)
-				return (false);
-			next = next->next->next;
-			if ((!prev || prev->type == AMPERSAND || prev->type == PIPE)
-				&& (!next || next->type == AMPERSAND || next->type == PIPE))
-				return (false);
+		if (!temp->next)
+			break ;
+		open = temp;
+		if (open->prev
+			&& (open->prev->type == NORMAL || is_redirection(open->prev)))
+		{
+			print_syntax_error(temp);
+			return (false);
 		}
-		prev = temp;
-		temp = temp->next;
+		while (temp->next && temp->type != PARENTHESIS_CLOSE)
+			temp = temp->next;
+		close = temp;
+		if (!is_correct_in_parenthesis(open, close))
+			return (false);
+		temp = close;
 	}
 	return (true);
 }
@@ -108,7 +138,7 @@ bool	is_valid_parenthesis(t_token *token, char **token_value)
  * Return     : true : 괄호가 올바른 위치에 있음
  *            : false: 괄호가 잘못된 위치에 있음
  */
-bool	is_valid_command(t_token *token, char **token_value)
+bool	is_valid_command(t_token *token)
 {
 	t_token	*temp;
 	bool	is_in_normal;
@@ -117,11 +147,10 @@ bool	is_valid_command(t_token *token, char **token_value)
 	is_in_normal = false;
 	while (temp)
 	{
-		*token_value = temp->value;
 		if (is_operator(temp) || temp->type == AMPERSAND)
 		{
 			if (!is_in_normal)
-				return (false);
+				break ;
 			is_in_normal = false;
 		}
 		else if (temp->type == NORMAL)
@@ -132,6 +161,9 @@ bool	is_valid_command(t_token *token, char **token_value)
 		temp = temp->next;
 	}
 	if (!is_in_normal)
-		return(false);
+	{
+		print_command_not_found(temp);
+		return (false);
+	}
 	return (true);
 }


### PR DESCRIPTION
### Description
 - `ls |`나 `ls &&` 등의 연산자로 명령어가 끝나면 터지는 에러 수정
 - 괄호 내 문법 검사 추가
 
## Proposed changes
 - 연산자 뒤에 아무것도 안 오는 경우  syntax error
 - 괄호 내부의 경우, `is_valid_syntax`를 재귀적으로 호출하여 검사

## Changed Files
- [X] `Makefile`
- [X] `error/dummy`
- [X] `error/syntax_error.c`
- [X] `include/parse.h`
- [X] 

## Checklist
- [X] Build Successfully
- [X] Checked Norminette
- [X] No leaks

## Screenshot
- (optional)
