### PR TITLE
🐛Bug(syntax): Overwriting the existing tree when creating a sub-tree

### DIFF
--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -32,7 +32,7 @@ int	make_parenthesis_node(t_ASTnode **ast_tree, t_token **current)
 	last_token->next = parent_token;
 	if (!new_tree)
 		return (FAIL);
-	if (*ast_tree && is_operator(*current))
+	if (*ast_tree && is_operator((*current)->prev))
 		add_node_to_direction(ast_tree, new_tree, RIGHT);
 	else
 		*ast_tree = new_tree;


### PR DESCRIPTION
### Description
 - 괄호 안의 토큰들을 서브 트리로 만들 때, 기존 트리의 루트 노드를 서브 트리의 루트 노드로 바꿈
 
## Proposed changes
 - 현재 토큰( value = '(' )이 연산자인지 보는 게 아니라, 이전 토큰이 연산자인지 확인

## Changed Files
- [X] `parse/ASTtree/make_node.c`

## Checklist
- [X] Build Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- (optional)
