### PR TITLE
🐛 Bug: ast tree clear node causes leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ sources1 += $(PARSE)/$(TOKEN)/free_token_list.c
 sources1 += $(PARSE)/$(TOKEN)/get_head_token.c
 sources1 += $(PARSE)/$(TOKEN)/get_last_token_in_parenthesis.c
 sources1 += $(PARSE)/$(TOKEN)/get_tail_token.c
+sources1 += $(PARSE)/$(TOKEN)/get_tokens_in_parenthesis.c
 sources1 += $(PARSE)/$(TOKEN)/handle_wildcard.c
 sources1 += $(PARSE)/$(TOKEN)/join_token_value.c
 sources1 += $(PARSE)/$(TOKEN)/set_fd_redirection_token.c

--- a/include/parse.h
+++ b/include/parse.h
@@ -20,7 +20,6 @@ typedef enum	e_token_type {
 	DAMPERSAND,
 	PIPE = '|',
 	DPIPE,
-	SEMICOLON = ';',
 	QUOTE = '\'',
 	DQUOTE = '\"',
 	WILDCARD = '*',

--- a/parse/ASTtree/clear_nodes.c
+++ b/parse/ASTtree/clear_nodes.c
@@ -11,6 +11,13 @@ void	clear_nodes(t_ASTnode **root)
 		return ;
 	clear_nodes(&(*root)->left);
 	clear_nodes(&(*root)->right);
+	free((*root)->token->value);
+	(*root)->token->value = NULL;
 	free((*root)->token);
+	(*root)->token = NULL;
+	(*root)->left = NULL;
+	(*root)->right = NULL;
+	(*root)->parent = NULL;
 	free(*root);
+	*root = NULL;
 }

--- a/parse/token/set_normal_token.c
+++ b/parse/token/set_normal_token.c
@@ -22,7 +22,7 @@ void	set_normal_token(t_token **token, char *trimmed_line, int *i)
 			set_quote_token(token, trimmed_line, i);
 			continue ;
 		}
-		else if (ft_strchr("<>()|;&", trimmed_line[*i]))
+		else if (ft_strchr("<>()|&", trimmed_line[*i]))
 			return ;
 		else if (!((*token)->is_in_escape) && trimmed_line[*i] == ESCAPE)
 		{

--- a/parse/token/set_operator_token.c
+++ b/parse/token/set_operator_token.c
@@ -11,8 +11,6 @@ enum e_token_type	get_operator_token_type(char c)
 		return (PARENTHESIS_OPEN);
 	else if (c == ')')
 		return (PARENTHESIS_CLOSE);
-	else if (c == ';')
-		return (SEMICOLON);
 	else if (c == '&')
 		return (AMPERSAND);
 	else if (c == '<')
@@ -63,7 +61,7 @@ void	set_operator_token(t_token **token, char *trimmed_line, int *i)
 	if ((*token)->value)
 		return ;
 	operator = &trimmed_line[*i];
-	if (ft_strchr("();", *operator))
+	if (ft_strchr("()", *operator))
 	{
 		join_token_value(token, trimmed_line, i);
 		(*token)->type = get_operator_token_type(*operator);

--- a/parse/token/set_token.c
+++ b/parse/token/set_token.c
@@ -13,7 +13,7 @@ void	set_token(t_token **token, char *trimmed_line, int *i)
 		set_normal_token(token, trimmed_line, i);
 	else if (is_quote(trimmed_line[*i]))
 		set_quote_token(token, trimmed_line, i);
-	else if (ft_strchr("<>()|;&", trimmed_line[*i]))
+	else if (ft_strchr("<>()|&", trimmed_line[*i]))
 		set_operator_token(token, trimmed_line, i);
 	else if (ft_isdigit(trimmed_line[*i]))
 		set_fd_redirection_token(token, trimmed_line, i);


### PR DESCRIPTION
### Description
 - ast tree를 free할 때, 할당 해제가 제대로 되지 않음
 
## Proposed changes
 - ast tree 내 token value를 할당 해제
 - 댕글링 포인터 처리
 - 세미콜론 토큰의 경우, 노말 토큰으로 간주

## Changed Files
- [X] `Makefile`
- [X] `parse/ASTtree/clear_nodes.c`

## Checklist
- [X] Build Successfully

## Screenshot
- (optional)
