### PR TITLE
⭐️ Feature: implement exit status in ft_unset()

### DIFF
--- a/builtin/ft_unset.c
+++ b/builtin/ft_unset.c
@@ -4,9 +4,9 @@
  * Description: 유효한 env 키 형식인지 확인한다.
  *              유효한 env 키 형식은 첫 글자가 알파벳인 경우에 해당한다.
  * Param.   #1: env 키를 담고 있는 문자열
- * Return     : 없음
+ * Return     : 유효하지 않을 경우 exit status가 1임을 나타내는 1을, 유효할 경우 0을 반환한다.
  */
-void	check_unset_argv(char *argv)
+int	check_unset_argv(char *argv)
 {
 	if (!((*argv >= 'A' && *argv <= 'Z')
 			|| (*argv >= 'a' && *argv <= 'z')))
@@ -14,27 +14,34 @@ void	check_unset_argv(char *argv)
 		ft_putstr_fd("minishell: unset: ", STDERR_FILENO);
 		ft_putstr_fd(argv, STDERR_FILENO);
 		ft_putstr_fd(": not a valid identifier\n", STDERR_FILENO);
-		g_var.exit_status = 1;
+		return (1);
 	}
+	return (0);
 }
 
 /*
  * Description: 주어진 문자열들을 키로 하는 env 값을 지운다.
  * Param.   #1: 'unset'을 포함하여 env 키들을 담고 있는 문자열 포인터
- * Return     : 0
+ * Return     : 에러가 있었을 경우 1을, 모두 성공적으로 실행했을 경우 0을 반환한다.
  */
 int	ft_unset(char **argv)
 {
 	char	*env;
 	int		i;
+	int		exit_status;
 
 	i = 0;
+	exit_status = 0;
 	while (argv[++i])
 	{
-		check_unset_argv(argv[i]);
+		if (check_unset_argv(argv[i]))
+		{
+			exit_status = 1;
+			continue ;
+		}
 		env = getenv(argv[i]);
 		if (env)
 			*env = '\0';
 	}
-	return (0);
+	return (exit_status);
 }

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -18,7 +18,7 @@ int	ft_export();
 int	ft_pwd();
 
 /*---------------------------------- UNSET ----------------------------------*/
-void	check_unset_argv(char *argv);
-int     ft_unset(char **argv);
+int	check_unset_argv(char *argv);
+int	ft_unset(char **argv);
 
 #endif

--- a/parse/token/expansion/interpret_exit_status.c
+++ b/parse/token/expansion/interpret_exit_status.c
@@ -12,7 +12,7 @@ void	interpret_exit_status(t_token **token, int *i)
 	char	*exit_status;
 	char	*temp;
 
-	exit_status = ft_itoa(0);
+	exit_status = ft_itoa(g_var.exit_status);
 	if (!(*token)->value)
 		(*token)->value = exit_status;
 	else


### PR DESCRIPTION
### Description
 - unset의 exit status 반환 구현
 
## Proposed changes
 - 에러가 날 시 1, 성공적으로 실행하면 0을 반환한다.

## Changed Files
- [X] `builtin/ft_unset.c`
- [X] `include/builtin.h`
- [X] `parse/token/expansion/interpret_exit_status.c`

## Checklist
- [X] Build Successfully

## Screenshot
- (optional)
