### PR TITLE
🐛 Bug: create duplicated nodes when trailing operators

### DIFF
--- a/parse/ASTtree/make_node.c
+++ b/parse/ASTtree/make_node.c
@@ -168,6 +168,7 @@ int	make_command_node(t_ASTnode **ast_tree, t_token **current)
 			return (ERROR);
 		add_node_to_direction(ast_tree, new_node, RIGHT);
 		*ast_tree = new_node;
+		return (SUCCESS);
 	}
 	if ((*current)->type == REDIRECT_IN || (*current)->type == REDIRECT_OUT
 		|| (*current)->type == DREDIRECT_IN


### PR DESCRIPTION
### Description
 - operator 뒤에 나오거나 첫 번째 노드를 생성할 때, 노드가 중복 생성됨
 
## Proposed changes
 - 해당 조건의 경우, 노드를 생성한 후 `SUCCESS`를 반환

## Changed Files
- [X] `parse/ASTtree/make_node.c`

## Checklist
- [X] Build Successfully

## Screenshot
- (optional)
