### PR TITLE
🐛 Bug: leaks wildcard

### DIFF
--- a/execute/heredoc.c
+++ b/execute/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/11 03:02:15 by chanheki          #+#    #+#             */
-/*   Updated: 2023/05/11 11:42:45 by yena             ###   ########.fr       */
+/*   Updated: 2023/05/14 15:25:07 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,6 @@ static void	run_code(char *str)
 	if (!root)
 		return ;
 	execute(root);
-	free_token_list(&(root->token));
 	clear_nodes(&root);
 }
 

--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: chanheki <chanheki@student.42.fr>          +#+  +:+       +#+        */
+/*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/11 02:00:36 by chanheki          #+#    #+#             */
-/*   Updated: 2023/05/11 12:01:16 by chanheki         ###   ########.fr       */
+/*   Updated: 2023/05/14 15:11:55 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,6 @@ static void	hosting_loop(void)
 		if (!root_node)
 			continue ;
 		execute(root_node);
-		free_token_list(&(root_node->token));
 		clear_nodes(&root_node);
 		free(str);
 	}

--- a/parse/ASTtree/clear_nodes.c
+++ b/parse/ASTtree/clear_nodes.c
@@ -6,7 +6,7 @@
 /*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 20:53:08 by yena              #+#    #+#             */
-/*   Updated: 2023/05/11 11:40:37 by yena             ###   ########.fr       */
+/*   Updated: 2023/05/14 15:17:09 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ void	clear_nodes(t_ASTnode **root)
 		return ;
 	clear_nodes(&(*root)->left);
 	clear_nodes(&(*root)->right);
+	free_token(&(*root)->token);
 	(*root)->left = NULL;
 	(*root)->right = NULL;
 	(*root)->parent = NULL;

--- a/parse/ASTtree/create_new_node.c
+++ b/parse/ASTtree/create_new_node.c
@@ -6,7 +6,7 @@
 /*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 20:53:13 by yena              #+#    #+#             */
-/*   Updated: 2023/05/10 20:53:14 by yena             ###   ########.fr       */
+/*   Updated: 2023/05/14 15:11:06 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ t_ASTnode	*create_new_node(t_token *token)
 	new_node = (t_ASTnode *)malloc(sizeof(t_ASTnode));
 	if (!new_node)
 		return (0);
-	new_node->token = token;
+	new_node->token = create_new_token(ft_strdup(token->value), token->type);
 	new_node->parent = NULL;
 	new_node->left = NULL;
 	new_node->right = NULL;

--- a/parse/parse.c
+++ b/parse/parse.c
@@ -6,7 +6,7 @@
 /*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 20:54:55 by yena              #+#    #+#             */
-/*   Updated: 2023/05/11 11:46:35 by yena             ###   ########.fr       */
+/*   Updated: 2023/05/14 15:11:47 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,5 +40,6 @@ t_ASTnode	*parse_command_line(char *line)
 	handle_wildcard(ast_tree);
 	if (!ast_tree)
 		return (free(line), free_token_list(&token), NULL);
+	free_token_list(&token);
 	return (ast_tree);
 }

--- a/parse/token/handle_wildcard.c
+++ b/parse/token/handle_wildcard.c
@@ -6,7 +6,7 @@
 /*   By: yena <yena@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 20:54:10 by yena              #+#    #+#             */
-/*   Updated: 2023/05/11 02:42:45 by yena             ###   ########.fr       */
+/*   Updated: 2023/05/14 15:24:11 by yena             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,7 +95,8 @@ int	rebuild_wildcard(t_ASTnode **node, int *dir_count, char *dir_name)
 	{
 		new_token = create_new_token(ft_strdup(dir_name), WILDCARD);
 		new_node = create_new_node(new_token);
-		if (!new_node || !new_token)
+		free_token(&new_token);
+		if (!new_node)
 			return (ERROR);
 		if ((*node)->left)
 			interrupt_to_left(node, new_node);


### PR DESCRIPTION
### Description
 - 와일드카드 해석 시, leaks 발생
 - `free_token_list`는 왼쪽, 오른쪽이 전부 연결된 와일드카드만 할당해제를 하지만, 와일드카드 해석 도중 생성된 토큰과 그 토큰으로 생성된 노드는 왼쪽, 오른쪽 연결이 되어있지 않음
 
## Proposed changes
 - 트리를 만들 때에는 개별적인 토큰을 생성하여 이용한다.
 - 트리를 모두 만든 후에는 토큰화 직후의 토큰을 `free_token_list`를 이용하여 free한다.
 - `clear_ast_tree`를 호출할 때에는 트리 내부의 토큰도 함께 free한다.

## Changed Files
- [X] `execute/heredoc.c`
- [X] `main.c`
- [X] `parse/ASTtree/clear_nodes.c`
- [X] `parse/ASTtree/create_new_node.c`
- [X] `parse/parse.c`
- [X] `parse/token/handle_wildcard.c`

## Checklist
- [X] Build Successfully
- [X] Norminette Checked
- [X] No leaks

## Screenshot
- (optional)
